### PR TITLE
Add Homebrew formula

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -1,0 +1,39 @@
+name: update-formula
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  bump-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set version variables
+        id: vars
+        run: |
+          echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          echo "tarball=${{ github.event.release.tarball_url }}" >> "$GITHUB_OUTPUT"
+
+      - name: Calculate checksum
+        run: |
+          curl -Ls "${{ steps.vars.outputs.tarball }}" | sha256sum | awk '{print $1}' > sha.txt
+          echo "sha=$(cat sha.txt)" >> "$GITHUB_ENV"
+
+      - name: Update formula
+        run: |
+          sed -i "s#url \".*\"#url \"https://github.com/wingsuitist/retry/archive/refs/tags/${{ steps.vars.outputs.tag }}.tar.gz\"#" Formula/retry.rb
+          sed -i "s/sha256 \".*\"/sha256 \"${sha}\"/" Formula/retry.rb
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/retry.rb
+          git commit -m "chore: update Homebrew formula for ${{ steps.vars.outputs.tag }}"
+          git push
+

--- a/Formula/retry.rb
+++ b/Formula/retry.rb
@@ -1,0 +1,17 @@
+class Retry < Formula
+  desc "The missing retry command"
+  homepage "https://github.com/wingsuitist/retry"
+  url "https://github.com/wingsuitist/retry/archive/refs/tags/v0.0.5.tar.gz"
+  sha256 "09042c64d36f33985d31d6b9fab93688cf13272fa15c9ba66b91f1723b499e23"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/"retry"), "./cmd"
+  end
+
+  test do
+    assert_match "command", shell_output("#{bin}/retry -h")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -53,3 +53,16 @@ For Windows, you will need a tool that can extract tar.gz archive like 7-Zip.
 1. Download your architecture's `.tar.gz` file from the [releases page](https://github.com/wingsuitist/retry/releases)
 2. Extract both the outer `.tar.gz` file and the resulting `.tar` file with 7-Zip.
 3. From the extracted files you can move the `retry.exe` to `C:\Windows\`.
+
+### Homebrew (macOS and Linux)
+
+You can install the `retry` command with [Homebrew](https://brew.sh/):
+
+```sh
+brew tap wingsuitist/retry
+brew install wingsuitist/retry/retry
+```
+
+The Homebrew formula is automatically updated by the release workflow whenever a
+new version of `retry` is published.
+


### PR DESCRIPTION
## Summary
- add a Formula/retry.rb for Homebrew
- document Homebrew install steps in README
- automatically update the formula on every release

## Testing
- `go test ./...` *(fails: command failed after 3 retries)*

------
https://chatgpt.com/codex/tasks/task_e_68665b3ac550832ab8d9ceb251a12d51