### PR TITLE
Fix tests by disabling CLI os.Exit

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -2,9 +2,15 @@ package main
 
 import (
 	"testing"
+
+	"github.com/urfave/cli/v2"
 )
 
 func TestRetryCommand(t *testing.T) {
+	origExiter := cli.OsExiter
+	cli.OsExiter = func(int) {}
+	defer func() { cli.OsExiter = origExiter }()
+
 	app := setupApp()
 	args := []string{"retry", "-c", "3", "-i", "1s", "-t", "1s", "--", "echo error 1>&2; false"}
 	err := app.Run(args)
@@ -23,5 +29,5 @@ func TestRetryCommand(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	
+
 }


### PR DESCRIPTION
## Summary
- avoid os.Exit in tests by overriding `cli.OsExiter`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6866a0c90c44832a8a1e5ab7c10b1be1